### PR TITLE
[CICD-222] Detect vendor and decode keys for Bitbucket

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -41,4 +41,3 @@ runs:
     PHP_LINT: ${{ inputs.PHP_LINT }}
     CACHE_CLEAR: ${{ inputs.CACHE_CLEAR }}
     SCRIPT: ${{ inputs.SCRIPT }}
-    CICD_VENDOR: 'e2e_tests'


### PR DESCRIPTION
# JIRA Ticket

[CICD-222](https://wpengine.atlassian.net/browse/CICD-222)

## What Are We Doing Here

SSH keys stored in Bitbucket Repository Variables must be base64 encoded, [as mentioned here](https://support.atlassian.com/bitbucket-cloud/docs/use-multiple-ssh-keys-in-your-pipeline/). That means we have to base64 decode the key when appropriate.

We can detect what CICD platform the container is running on by checking environment variables. If it's Bitbucket, we'll base64 decode the SSH key before creating the key file that is used to connect.
