### PR TITLE
[NO-JIRA] Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "wpengine/p-e-team-domino"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "wpengine/p-e-team-domino"


### PR DESCRIPTION
# JIRA Ticket

[NO-JIRA], but related to [[CICD-301]](https://wpengine.atlassian.net/browse/CICD-301)

## What Are We Doing Here

Creating a [dependabot.yml ](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) to monitor the dockerfile for vulnerabilities.

[CICD-301]: https://wpengine.atlassian.net/browse/CICD-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ