### PR TITLE
[CICD-190] Replace deprecated set output command

### DIFF
--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -13,14 +13,11 @@ on:
 jobs:
   run_action:
     runs-on: ubuntu-latest
-    outputs:
-      status: ${{ steps.deploy.outputs.status }}
-    steps: 
+    steps:
       - uses: actions/checkout@v3
       - name: Bump test plugin version number
         run: sed -i 's/0.0.1/0.0.2/' tests/data/plugins/test-plugin/test-plugin.php
       - name: Deploy to WP Engine
-        id: deploy
         uses: ./.github/actions/deploy
         with:
           # Deploy vars 
@@ -33,16 +30,21 @@ jobs:
           FLAGS: '-r --backup --backup-dir=/tmp --itemize-changes'
           SCRIPT: "tests/data/post-deploy/test-plugin.sh"
           CACHE_CLEAR: true
-  validate_result:
+      - name: Fetch deploy results
+        id: fetchResult
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: "https://sitedeploye2e.wpengine.com/wp-content/plugins/test-plugin/status.json"
+      - name: Validate deploy results
+        run: |
+          [ ${{ fromJson(steps.fetchResult.outputs.response).status }} = "success" ] || exit 1
+  notify:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     needs: run_action
     steps:
-      - name: Validate deploy results
-        run: |
-          [ ${{needs.run_action.outputs.status}} = "pass" ] || exit 1
       - name: Notify slack on failure
-        if: failure() && github.ref == 'refs/heads/main'
+        if: needs.run_action.result == 'failure' && github.ref == 'refs/heads/main'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/tests/data/post-deploy/test-plugin.sh
+++ b/tests/data/post-deploy/test-plugin.sh
@@ -3,6 +3,7 @@
 BACKUP_DIR=/tmp
 PLUGINS_DIR=wp-content/plugins
 PLUGIN_NAME=test-plugin
+STATUS_FILE=status.json
 
 cleanup() {
     rm tests/data/post-deploy/test-plugin.sh
@@ -26,8 +27,8 @@ echo "Old test plugin version: $BEFORE_PLUGIN_VERSION"
 # Check that the expected update was made
 if [ -z "$BEFORE_PLUGIN_VERSION" ] || [ -z "$AFTER_PLUGIN_VERSION" ] || [ "$BEFORE_PLUGIN_VERSION" = "$AFTER_PLUGIN_VERSION" ]; then
     echo "Failure: Test plugin was not updated!"
-    echo "::set-output name=status::fail"
+    echo "{\"status\": \"failure\"}" > $PLUGINS_DIR/$PLUGIN_NAME/$STATUS_FILE
 else
     echo "Success: Test plugin successfully updated from $BEFORE_PLUGIN_VERSION to $AFTER_PLUGIN_VERSION!"
-    echo "::set-output name=status::pass"
+    echo "{\"status\": \"success\"}" > $PLUGINS_DIR/$PLUGIN_NAME/$STATUS_FILE
 fi


### PR DESCRIPTION
# JIRA Ticket

[CICD-190](https://wpengine.atlassian.net/browse/CICD-190)

## What Are We Doing Here

Replaces the need to use the deprecated `set-output` command in our post-deploy script. Instead of setting an output, we'll write a status file that the next step can retrieve using an HTTP request.

This is identical to the changes made for the GHA https://github.com/wpengine/github-action-wpe-site-deploy/pull/71/commits/ce6a3f8604a9065a4f0b7b452689355f931c5194.


[CICD-190]: https://wpengine.atlassian.net/browse/CICD-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ