### PR TITLE
[CICD-483] Bump alpine 3.17 > 3.18

### DIFF
--- a/.changeset/shiny-numbers-cheer.md
+++ b/.changeset/shiny-numbers-cheer.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/site-deploy": patch
+---
+
+Bump alpine 3.17 > 3.18

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM instrumentisto/rsync-ssh:alpine3.17
+FROM instrumentisto/rsync-ssh:alpine3.18
 # Intsall dependencies
 RUN apk add bash php
 # Add entrypoint and excludes


### PR DESCRIPTION
# JIRA Ticket

[CICD-483](https://wpengine.atlassian.net/browse/CICD-483)

## What Are We Doing Here

<!--Here is where you should describe the problem you are solving, adding any fine details on the solution that might
otherwise not be recognizable for someone unfamiliar with the changes. Add some pictures if it helps.-->

Bumping alpine base image from 3.17 to 3.18 to resolve vulnerabilities
![Screenshot 2023-10-24 at 4 48 17 PM](https://github.com/wpengine/site-deploy/assets/26469099/2f386090-dcf3-4e49-b8ce-cae38d1fe7be)

## How to Test
- Pull Down Branch
- Start Docker
- Run `make build` 
- See Image report 0 vulnerabilities locally
![Screenshot 2023-10-24 at 4 22 45 PM](https://github.com/wpengine/site-deploy/assets/26469099/e12e8806-0069-4849-ae16-7c7dd88ab09f)
- Confirm [this branch in DockerHub](https://hub.docker.com/layers/wpengine/site-deploy/branch-CICD-493_image-vulns/images/sha256-11240031e24110d8bb9f463c51972c6e6c2343f8bd5d312abbf4557769d285cb?tab=vulnerabilities) also has 0 vulnerabilities reported
![Screenshot 2023-10-24 at 5 04 49 PM](https://github.com/wpengine/site-deploy/assets/26469099/2fc5b7e4-e515-412f-8032-6df9519a9a0c)
> [!NOTE]  
> DockerHub is still listing a vulnerability, even though it says "Zero found". It's listed as a 0 level severity though, so it might be okay for now. I'd expect another alpine release to clean that up in the coming weeks. 

[CICD-483]: https://wpengine.atlassian.net/browse/CICD-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
