### PR TITLE
[CICD-749] Update base image alpine

### DIFF
--- a/.changeset/sweet-cameras-thank.md
+++ b/.changeset/sweet-cameras-thank.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/site-deploy": patch
+---
+
+Update base image alpine 3.18 > 3.20 and apply updates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM instrumentisto/rsync-ssh:alpine3.18
+FROM instrumentisto/rsync-ssh:alpine3.20
 # Intsall dependencies
 RUN apk add bash php
 # Add entrypoint and excludes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM instrumentisto/rsync-ssh:alpine3.20
 # Intsall dependencies
-RUN apk add bash php
+RUN apk update \
+ && apk upgrade \
+ && apk add --no-cache \
+            bash \
+            php \
+ && rm -rf /var/cache/apk/*
 # Add entrypoint and excludes
 ADD entrypoint.sh /entrypoint.sh
 ADD exclude.txt /exclude.txt


### PR DESCRIPTION
# JIRA Ticket

[CICD-749](https://wpengine.atlassian.net/browse/CICD-749)

## What Are We Doing Here

Updates base `instrumentisto/rsync-ssh` image and applies updates.


[CICD-749]: https://wpengine.atlassian.net/browse/CICD-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ