### PR TITLE
[CICD-756] Update dependencies in version and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
       version: ${{ steps.version.outputs.CURRENT_VERSION }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 16.x
-        uses: actions/setup-node@v2
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install Dependencies
         run: npm ci
@@ -46,7 +46,7 @@ jobs:
     if: needs.versioning.outputs.hasChangesets == 'false'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -55,10 +55,10 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
 
-      - name: Setup Node.js 16.x
-        uses: actions/setup-node@v2
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Publish tags
         id: publish


### PR DESCRIPTION
# JIRA Ticket

[CICD-756](https://wpengine.atlassian.net/browse/CICD-756)

## What Are We Doing Here

Following #25, our version and release workflow failed due to node incompatibility. This PR bumps node in the workflow to v20. Additionally, I've bumped the version on the `checkout` and `setup-node` actions to their latest versions.


[CICD-756]: https://wpengine.atlassian.net/browse/CICD-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ