### PR TITLE
[CICD-730] Exclude wp-cache-memcached from all deploys

### DIFF
--- a/.changeset/wicked-tables-tap.md
+++ b/.changeset/wicked-tables-tap.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/site-deploy": patch
+---
+
+Adds wp-cache-memcached to default excludes list

--- a/exclude.txt
+++ b/exclude.txt
@@ -55,6 +55,7 @@ wp-content/mu-plugins/wpe-wp-sign-on-plugin*
 wp-content/mu-plugins/wpe-elasticpress-autosuggest-logger*
 wp-content/mu-plugins/wpe-cache-plugin*
 wp-content/mu-plugins/wp-cache-memcached*
+wp-content/drop-ins/
 wp-content/drop-ins/wp-cache-memcached*
 wp-content/mysql.sql
 

--- a/exclude.txt
+++ b/exclude.txt
@@ -54,6 +54,8 @@ wp-content/mu-plugins/wpengine-common*
 wp-content/mu-plugins/wpe-wp-sign-on-plugin*
 wp-content/mu-plugins/wpe-elasticpress-autosuggest-logger*
 wp-content/mu-plugins/wpe-cache-plugin*
+wp-content/mu-plugins/wp-cache-memcached*
+wp-content/drop-ins/wp-cache-memcached*
 wp-content/mysql.sql
 
 # Local specific


### PR DESCRIPTION
# JIRA Ticket

[CICD-730](https://wpengine.atlassian.net/browse/CICD-730)

## What Are We Doing Here

There's a new plugin being installed by the WP Engine platform. It started as an `mu-plugin` and has since been moved to a folder called `drop-ins`. This PR adds both locations to our rsync excludes list to prevent users from accidentally overwriting or deleting the plugin.

[CICD-730]: https://wpengine.atlassian.net/browse/CICD-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ