### PR TITLE
[CICD-583] Split FLAGS variable into an array

### DIFF
--- a/.changeset/nervous-bobcats-fry.md
+++ b/.changeset/nervous-bobcats-fry.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/site-deploy": patch
+---
+
+Fixes a bug that caused certain flags in the FLAGS option to be incorrectly parsed by rsync

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update \
             php \
  && rm -rf /var/cache/apk/*
 # Add entrypoint and excludes
+ADD functions.sh /functions.sh
 ADD entrypoint.sh /entrypoint.sh
 ADD exclude.txt /exclude.txt
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ version: build
 	docker image tag $(IMAGE) $(IMAGE_NAME):v$(MAJOR_VERSION) && \
 	docker image tag $(IMAGE) $(IMAGE_NAME):v$(MAJOR_VERSION).$(MINOR_VERSION) && \
 	docker image tag $(IMAGE) $(IMAGE_NAME):v$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
+
+test:
+	./tests/test_functions.sh

--- a/README.md
+++ b/README.md
@@ -20,13 +20,22 @@ You can use this image to deploy a site from your local machine.
 2. Change directories into the root of the local site you'd like to deploy.
 3. Create a `.env` file with the following variables, changing their values as needed.
 
+> [!WARNING]  
+> Since `docker run` does not strip double-quotes from variables in the .env file, we don't use them
+> to wrap entire variable values. Instead, we must use single or double-quotes around flag values that
+> contain whitespace to prevent splitting (`--filter=':= .gitignore'`). The `=` sign between the flag
+> and its value is also required (`--filter=':= .gitignore'` rather than `--filter ':= .gitignore'`).
+
 ```sh
-WPE_ENV=yourinstall # The target WP Engine install name.
+# Required. The target WP Engine install name.
+WPE_ENV=yourinstall
+# Optional. Default values shown.
 REMOTE_PATH=
 SRC_PATH=.
-PHP_LINT=TRUE
+PHP_LINT=FALSE
 CACHE_CLEAR=TRUE
 SCRIPT=
+FLAGS=-azvr --inplace --exclude='.*'
 ```
 
 3. Set an environment variable with your private SSH key, replacing the key file name with your own.

--- a/functions.sh
+++ b/functions.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+# Function to parse FLAGS into an array
+# 
+# Bash doesn't respect quotes when splitting the FLAGS string on whitespace
+# which can lead to incorrect splitting on arguments like --filter=':- .gitignore'.
+#
+# xargs does respect quotes, so we use that here to convert the string into a null-delimited
+# sequence of arguments. We then read that sequence into an array by splitting on the null character.
+#
+# https://superuser.com/questions/1529226/get-bash-to-respect-quotes-when-word-splitting-subshell-output
+parse_flags() {
+  local flags="$1"
+  FLAGS_ARRAY=()
+  while IFS= read -r -d '' flag; do FLAGS_ARRAY+=("$flag"); done < <(echo "$flags" | xargs printf '%s\0')
+}
+
+print_deployment_info() {
+  echo "Deploying your code to:"
+  echo -e "\t${WPE_ENV_NAME}"
+  echo -e "with the following ${#FLAGS_ARRAY[@]} rsync argument(s):"
+  for flag in "${FLAGS_ARRAY[@]}"; do
+    echo -e "\t$flag"
+  done
+}

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color

--- a/tests/test_flag_formats.sh
+++ b/tests/test_flag_formats.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Demonstrates the different ways to pass flags to rsync.
+# 
+# When determining the correct way to pass flags to rsync, it is helpful to
+# understand how the shell interprets quotes and whitespace. This script runs
+# in debug mode to show how the shell interprets the flags for each test case.
+#
+# This is a stand-alone script. It is only meant for demonstration and does not
+# directly test code in this project.
+
+# Get the directory of the current script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${SCRIPT_DIR}/common.sh"
+
+set -x
+
+FLAGS="-avzr --filter=':- .gitignore' --exclude='.*'"
+FLAGS_ARRAY=("-avzr" "--filter=:- .gitignore" "--exclude='.*'")
+
+test_flags_no_quotes() {
+  rsync $FLAGS --dry-run "$SCRIPT_DIR"/data . > /dev/null
+  if [ $? -eq 0 ]; then
+    echo -e "${GREEN}test_flags_no_quotes: Success${NC}"
+  else
+    echo -e "${RED}test_flags_no_quotes: Failure${NC}"
+  fi
+}
+
+test_flags_double_quotes() {
+  rsync "$FLAGS" --dry-run "$SCRIPT_DIR"/data . > /dev/null
+  if [ $? -eq 0 ]; then
+    echo -e "${GREEN}test_flags_double_quotes: Success${NC}"
+  else
+    echo -e "${RED}test_flags_double_quotes: Failure${NC}"
+  fi
+}
+
+test_flags_array() {
+  rsync "${FLAGS_ARRAY[@]}" --dry-run "$SCRIPT_DIR"/data . > /dev/null
+  if [ $? -eq 0 ]; then
+    echo -e "${GREEN}test_flags_array: Success${NC}"
+  else
+    echo -e "${RED}test_flags_array: Failure${NC}"
+  fi
+}
+
+main() {
+  test_flags_no_quotes
+  test_flags_double_quotes
+  test_flags_array
+}
+
+main

--- a/tests/test_functions.sh
+++ b/tests/test_functions.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Get the directory of the current script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${SCRIPT_DIR}/common.sh"
+source "${SCRIPT_DIR}/../functions.sh"
+
+# First argument represents the value of the FLAGS variable.
+# The rest of the arguments represent the expected values of the FLAGS_ARRAY.
+#
+# usage: test_parse_flags <FLAGS> <EXPECTED_FLAGS...>
+test_parse_flags() {
+  local test_case=$1
+  shift
+  local expected_args=("$@")
+
+  parse_flags "$test_case"
+
+  local actual_count="${#FLAGS_ARRAY[@]}"
+  local expected_count="${#expected_args[@]}"
+
+  if [[ "$actual_count" -ne "$expected_count" ]]; then
+    echo -e "${RED}Test failed for FLAGS='$test_case': expected $expected_count arguments, got $actual_count."
+    echo -e "\tActual arguments: ${FLAGS_ARRAY[*]}${NC}"
+    return
+  fi
+
+  for i in "${!expected_args[@]}"; do
+    if [[ "${FLAGS_ARRAY[$i]}" != "${expected_args[$i]}" ]]; then
+      echo -e "${RED}Test failed for FLAGS='$test_case': expected '${expected_args[$i]}', got '${FLAGS_ARRAY[$i]}'.${NC}"
+      return
+    fi
+  done
+
+  echo -e "${GREEN}Test passed for FLAGS=\"$test_case\".${NC}"
+}
+
+# Test cases
+test_parse_flags \
+  "-azvr --inplace --exclude='.*'" \
+  "-azvr" \
+  "--inplace" \
+  "--exclude=.*"
+
+test_parse_flags \
+  '-azvr --inplace --exclude=".*"' \
+  "-azvr" \
+  "--inplace" \
+  "--exclude=.*"
+
+test_parse_flags \
+  "-azvr --filter=':- .gitignore' --exclude='.*'" \
+  "-azvr" \
+  "--filter=:- .gitignore" \
+  "--exclude=.*"
+
+test_parse_flags \
+  "-avzr --delete --filter='P /wp-uploads/**'" \
+  "-avzr" \
+  "--delete" \
+  "--filter=P /wp-uploads/**"
+
+test_parse_flags \
+  "-avzr --delete --exclude='\$dollar'" \
+  "-avzr" \
+  "--delete" \
+  "--exclude=\$dollar"
+
+test_parse_flags \
+  "-avzr --exclude='\`back-ticks\`'" \
+  "-avzr" \
+  "--exclude=\`back-ticks\`"
+
+test_parse_flags \
+  "-avzr --exclude='path\\with\\backslash'" \
+  "-avzr" \
+  "--exclude=path\\with\\backslash"


### PR DESCRIPTION
# JIRA Ticket

[CICD-583](https://wpengine.atlassian.net/browse/CICD-583)

## What Are We Doing Here

### 1. Converting the FLAGS variable to an array

Rsync flags sometimes include whitespace in the flag's value. For example, `--filter=':- .gitignore'` includes whitespace between the filter rule and the file name. The single quotes surrounding the flag's value are meant to prevent splitting. Unfortunately, when bash expands the `$FLAGS` variable as part of the main rsync command it escapes the single quotes (`'\''`)and then splits on the whitespace between `:-` and `.gitignore`. This was causing rsync to see the filter flag as two separate arguments, `--filter=:-` and `.gitignore`. For example:

```bash
FLAGS="-avzr --filter=':- .gitignore' --exclude='.*'"
# Using $FLAGS without quotes
rsync $FLAGS src/ dest/
# ...expands to...
rsync -avzr '--filter='\'':-' '.gitignore'\''' '--exclude='\''.*'\''' src/ dest/
# ...resulting in the error...
Unknown filter rule: `':-'
```

If the example above hadn't encountered the error with `--filter`, it still would have misinterpreted the `--exclude` rule and not excluded dotfiles from the deploy.

Simply double-quoting  `$FLAGS` string doesn't help because it prevents splitting between flags when multiple are provided. For example:

```bash
FLAGS="-avzr --filter=':- .gitignore' --exclude='.*'"
# Double-quoting $FLAGS
rsync "$FLAGS" src/ dest/
# ...expands to...
rsync '-avzr --filter='\'':- .gitignore'\'' --exclude='\''.*'\''' src/ dest/
# ...resulting in the error...
rsync: -avzr --filter=':- .gitignore' --exclude='.*': unknown option
```

To fix this, we needed to split the `FLAGS` variable into an array while respecting single quotes. This pre-split array can be passed to rsync with double-quotes to prevent further splitting. So we end up with:

```bash
FLAGS_ARRAY=("-avzr" "--filter=:- .gitignore" "--exclude='.*'")
# Double-quoting $FLAGS_ARRAY[@]
rsync "${FLAGS_ARRAY[@]}" src/ dest/
# ...expands to...
rsync -avzr '--filter=:- .gitignore' '--exclude=.*' src/ dest/
# No errors!
```

### 2. Enabling debug mode for the main rsync command

Bash [debug mode](https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_02_03.html) was especially useful for determining how the `FLAGS` input was being transformed in all these different cases. I believe it would be just as useful for GitHub Actions and Bitbucket Pipelines users to spot issues with escaping in their `FLAGS` input. For that reason, I've left debug mode on for the main rsync call. Users will now see output similar to:

```
+ rsync '--rsh=ssh -v -p 22 -i /root/.ssh/wpe_id_rsa -o StrictHostKeyChecking=no -o '\''ControlPath=/root/.ssh/ctl/%C'\''' -avzr '--filter=:- .gitignore' --exclude-from=/exclude.txt --chmod=D775,F664 . wpe_cicd+installname@installname.ssh.wpengine.net:sites/installname/
```

### 3. Starting a new functions.sh file

Testing these changes has been pretty difficult given that we don't have anything more granular than an end-to-end smoke test configured for this project. Fixing that is beyond the scope of this PR, but I did take the opportunity to set us up for unit testing in the future by putting the new functions I added into a separate file. This allowed me to test the function independently of a full deploy using several different test cases. In the future, we can formalize this a bit more, add a framework like (bats)[https://bats-core.readthedocs.io/en/stable/], and extract other functions from `entrypoint.sh`.

## Testing

I've added tests for the `parse_flags` function. You can run those using make.

```
make test
```

Additionally, I've included a demo script that illustrates the need to parse FLAGS into an array using the examples described above. You can run that one as a stand-alone script.

```
./tests/test_flag_formats.sh
```

[CICD-583]: https://wpengine.atlassian.net/browse/CICD-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ