### PR TITLE
[NOJIRA] Add versioning step to update lock file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           commit: "Version Image"
           title: "Version Image"
+          version: npm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "dependencies": {},
   "devDependencies": {
     "@changesets/cli": "^2.26.2"
+  },
+  "scripts": {
+    "version": "changeset version && npm install --package-lock-only"
   }
 }


### PR DESCRIPTION
# JIRA Ticket

[NOJIRA]

## What Are We Doing Here

When bumping versions during automated release, the package-lock file is not updated with new root package versions.

This PR adds a step to the release workflow to update package-lock as part of changeset versioning.
