### PR TITLE
[CICD-497] Add concurrency queueing to e2e deploy workflow

### DIFF
--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-main
+  cancel-in-progress: false
 
 jobs:
   run_action:
@@ -21,7 +24,7 @@ jobs:
         uses: ./.github/actions/deploy
         with:
           # Deploy vars 
-          WPE_SSHG_KEY_PRIVATE: ${{ secrets.WPE_SSHG_KEY_PRIVATE }} 
+          WPE_SSHG_KEY_PRIVATE: ${{ secrets.WPE_SSHG_KEY_PRIVATE }}
           WPE_ENV: sitedeploye2e
           # Deploy Options
           SRC_PATH: "tests/data/plugins/test-plugin"


### PR DESCRIPTION
# JIRA Ticket

[CICD-497](https://wpengine.atlassian.net/browse/CICD-497)

## What Are We Doing Here

Creates a queue when the e2e deploy testing workflow is triggered in an attempt to curb irrelevant notifications.


[CICD-497]: https://wpengine.atlassian.net/browse/CICD-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ