### PR TITLE
[CICD-496] Fix autogenerated release notes

### DIFF
--- a/.github/actions/get-release-notes/action.yml
+++ b/.github/actions/get-release-notes/action.yml
@@ -17,8 +17,7 @@ runs:
     - id: notes
       run: |
           notes=$(node ${{ github.action_path }}/getReleaseNotes ${{ inputs.version }} ${{ inputs.changelog }})
-          notes="${notes//'%'/'%25'}"
-          notes="${notes//$'\n'/'%0A'}"
-          notes="${notes//$'\r'/'%0D'}"
-          echo "RELEASE_NOTES=$notes" >> $GITHUB_OUTPUT
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
+          echo "$notes" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
# JIRA Ticket

[CICD-496](https://wpengine.atlassian.net/browse/CICD-496)

## What Are We Doing Here

Newline characters are not currently encoded properly when release notes are autogenerated.

This PR uses the `EOF` syntax (now recommended by GitHub) to handle encoding of the multi-line release note string.

## Testing

For ease in testing locally, it is recommended for [`act`](https://github.com/nektos/act) to be installed:

```sh
brew install act
```

### Steps Taken

First, I added a test workflow called `test-get-release-notes.yml` with the following contents:

```yml
name: Test Get Release Notes

on: push

jobs:
  test-get-release-notes:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout Repo
        uses: actions/checkout@v4

      - name: Setup Node.js 20.x
        uses: actions/setup-node@v4
        with:
          node-version: 20.x

      - name: Get release notes
        id: notes
        uses: ./.github/actions/get-release-notes
        with:
          version: '1.0.3'
          changelog: ./CHANGELOG.md

      - name: Print release notes
        run: echo "${{ steps.notes.outputs.release_notes }}"
```

Next, I ran the test workflow:

```sh
act push -j test-get-release-notes
```

Lastly, I observed the printed release notes:

```
| ## Patch Changes
|
| - f1e6867: Bump node version for dev tooling
| - 43ebea6: Update base image alpine 3.18 > 3.20 and apply updates
| - 504f3db: Update dev tooling npm dependencies
```

Previously, the notes were printed as a single line:

```
| %0A## Patch Changes%0A%0A- f1e6867: Bump node version for dev tooling%0A- 43ebea6: Update base image alpine 3.18 > 3.20 and apply updates%0A- 504f3db: Update dev tooling npm dependencies
```

[CICD-496]: https://wpengine.atlassian.net/browse/CICD-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ