### PR TITLE
[CICD-761] Actually fix excludes

### DIFF
--- a/.changeset/cool-shirts-reflect.md
+++ b/.changeset/cool-shirts-reflect.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/site-deploy": patch
+---
+
+[CICD-761] Actually fix excludes.txt, removes out relative folder pathing

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM instrumentisto/rsync-ssh:alpine3.20
+FROM instrumentisto/rsync-ssh:alpine3.20 AS build
 # Intsall dependencies
 RUN apk update \
  && apk upgrade \
@@ -11,3 +11,6 @@ ADD functions.sh /functions.sh
 ADD entrypoint.sh /entrypoint.sh
 ADD exclude.txt /exclude.txt
 ENTRYPOINT ["/entrypoint.sh"]
+
+FROM build AS test
+COPY tests /tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM instrumentisto/rsync-ssh:alpine3.20 AS build
+FROM instrumentisto/rsync-ssh:alpine3.20
 # Intsall dependencies
 RUN apk update \
  && apk upgrade \
@@ -12,5 +12,3 @@ ADD entrypoint.sh /entrypoint.sh
 ADD exclude.txt /exclude.txt
 ENTRYPOINT ["/entrypoint.sh"]
 
-FROM build AS test
-COPY tests /tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,3 @@ ADD functions.sh /functions.sh
 ADD entrypoint.sh /entrypoint.sh
 ADD exclude.txt /exclude.txt
 ENTRYPOINT ["/entrypoint.sh"]
-

--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,7 @@ test-unit:
 	./tests/test_functions.sh
 	
 test-integration:
-	@echo 🧪 Executing Relative Remote Tests...
-	docker compose up test
+	# TODO: Currently commenting out the integration tests as they are not ready yet
+	# this was setup for the relative remote work, and is not currently working with 
+	# testing sync_files function.
+	# docker compose up test

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,5 @@ version: build
 	docker image tag $(IMAGE) $(IMAGE_NAME):v$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 
 test:
-	./tests/test_functions.sh
+	@echo 🧪 Executing Unit Tests...
+	docker compose up

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ version: build
 	docker image tag $(IMAGE) $(IMAGE_NAME):v$(MAJOR_VERSION).$(MINOR_VERSION) && \
 	docker image tag $(IMAGE) $(IMAGE_NAME):v$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 
-test:
-	@echo 🧪 Executing Unit Tests...
-	docker compose up
+test-unit:
+	./tests/test_functions.sh
+	
+test-integration:
+	@echo 🧪 Executing Relative Remote Tests...
+	docker compose up test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: test
     image: wpengine/site-deploy:latest
     platform: linux/amd64
     entrypoint: /tests/test-make-relative-remote/test.sh
+    #connects local directory to container directory
     volumes:
       - ./tests/workspace:/workspace
+      - ./tests:/tests
     depends_on:
       - build
 
@@ -17,5 +18,4 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: build
     command: /bin/true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  test:
+    env_file:
+      - .env
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: wpengine/site-deploy:latest
+    platform: linux/amd64
+    entrypoint: /bin/bash -c "/app/tests/test_functions.sh && tail -f /dev/null"
+    volumes:
+      - .:/app
+    depends_on:
+      - build
+    working_dir: /app/tests
+
+  build:
+    image: wpengine/site-deploy:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: /bin/true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,21 @@
 services:
   test:
-    env_file:
-      - .env
     build:
       context: .
       dockerfile: Dockerfile
+      target: test
     image: wpengine/site-deploy:latest
     platform: linux/amd64
-    entrypoint: /bin/bash -c "/app/tests/test_functions.sh && tail -f /dev/null"
+    entrypoint: /tests/test-make-relative-remote/test.sh
     volumes:
-      - .:/app
+      - ./tests/workspace:/workspace
     depends_on:
       - build
-    working_dir: /app/tests
 
   build:
     image: wpengine/site-deploy:latest
     build:
       context: .
       dockerfile: Dockerfile
+      target: build
     command: /bin/true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,6 +106,10 @@ check_cache() {
   fi
 }
 
+check_folder() {
+  make_relative_remote "$SRC_PATH" "$REMOTE_PATH"
+}
+
 sync_files() {
   #create multiplex connection 
   ssh -nNf -v -i "${WPE_SSHG_KEY_PRIVATE_PATH}" -o StrictHostKeyChecking=no -o ControlMaster=yes -o ControlPath="$SSH_PATH/ctl/%C" "$WPE_FULL_HOST"
@@ -146,4 +150,5 @@ setup_env
 setup_ssh_dir
 check_lint
 check_cache
+check_folder
 sync_files

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,10 +106,6 @@ check_cache() {
   fi
 }
 
-check_folder() {
-  make_relative_remote "$SRC_PATH" "$REMOTE_PATH"
-}
-
 sync_files() {
   #create multiplex connection 
   ssh -nNf -v -i "${WPE_SSHG_KEY_PRIVATE_PATH}" -o StrictHostKeyChecking=no -o ControlMaster=yes -o ControlPath="$SSH_PATH/ctl/%C" "$WPE_FULL_HOST"
@@ -150,5 +146,4 @@ setup_env
 setup_ssh_dir
 check_lint
 check_cache
-check_folder
 sync_files

--- a/exclude.txt
+++ b/exclude.txt
@@ -18,17 +18,17 @@ Thumbs.db
 # NOTE:
 #     These files are excluded from the deploy so as to prevent unwanted errors from occurring, 
 #     such as accidentally deploying a local version of wp-config.php or accidentally deleting
-#     wp-content/uploads/ if a --delete flag is passed while deploying root. Most paths here 
+#     uploads/ if a --delete flag is passed while deploying root. Most paths here 
 #     are ingnored in the WPE sample .gitignore per best practice.
 wp-config.php
-wp-content/uploads/
-wp-content/blogs.dir/
-wp-content/upgrade/*
-wp-content/backup-db/*
-wp-content/advanced-cache.php
-wp-content/wp-cache-config.php
-wp-content/cache/*
-wp-content/cache/supercache/*
+uploads/
+blogs.dir/
+upgrade/*
+backup-db/*
+advanced-cache.php
+wp-cache-config.php
+cache/*
+cache/supercache/*
 
 # WP Engine specific files
 # NOTE:
@@ -44,20 +44,20 @@ wp-content/cache/supercache/*
 .wpe-devkit/
 .wpengine-conf/
 _wpeprivate
-wp-content/object-cache.php
-wp-content/mu-plugins/mu-plugin.php
-wp-content/mu-plugins/slt-force-strong-passwords.php
-wp-content/mu-plugins/wpengine-security-auditor.php
-wp-content/mu-plugins/stop-long-comments.php
-wp-content/mu-plugins/force-strong-passwords*
-wp-content/mu-plugins/wpengine-common*
-wp-content/mu-plugins/wpe-wp-sign-on-plugin*
-wp-content/mu-plugins/wpe-elasticpress-autosuggest-logger*
-wp-content/mu-plugins/wpe-cache-plugin*
-wp-content/mu-plugins/wp-cache-memcached*
-wp-content/drop-ins/
-wp-content/drop-ins/wp-cache-memcached*
-wp-content/mysql.sql
+object-cache.php
+mu-plugin.php
+slt-force-strong-passwords.php
+wpengine-security-auditor.php
+stop-long-comments.php
+force-strong-passwords*
+wpengine-common*
+wpe-wp-sign-on-plugin*
+wpe-elasticpress-autosuggest-logger*
+wpe-cache-plugin*
+wp-cache-memcached*
+drop-ins/
+drop-ins/wp-cache-memcached*
+mysql.sql
 
 # Local specific
-wp-content/mu-plugins/local-by-flywheel-live-link-helper.php
+local-by-flywheel-live-link-helper.php

--- a/functions.sh
+++ b/functions.sh
@@ -25,3 +25,36 @@ print_deployment_info() {
     echo -e "\t$flag"
   done
 }
+
+# Function to check REMOTE_PATH and move contents of SRC_PATH
+make_relative_remote() {
+  if [[ -z "$REMOTE_PATH" && "$SRC_PATH" == "." ]]; then
+    echo "Default usage, no moving relative paths needed 👋"
+    return
+  fi
+
+  # Not sure if this check is necessary
+  if [[ "$SRC_PATH" == "$REMOTE_PATH" ]]; then
+      echo "SRC_PATH and REMOTE_PATH are the same, no moving relative paths needed 👋"
+      return
+  fi
+
+    # Echo the paths for debugging
+    echo "SRC_PATH: $SRC_PATH"
+    echo "REMOTE_PATH: $REMOTE_PATH"
+    mkdir -p "$REMOTE_PATH"
+    echo "Would have moved contents of SRC_PATH to REMOTE_PATH"
+  
+    if [ "$SRC_PATH" == "." ]; then
+        # Use a temporary directory to avoid moving REMOTE_PATH into itself
+        TMP_DIR=$(mktemp -d)
+        mv "$SRC_PATH"/* "$TMP_DIR"
+        mv "$TMP_DIR"/* "$REMOTE_PATH"
+        rmdir "$TMP_DIR"
+    else
+        mv "$SRC_PATH"/* "$REMOTE_PATH"
+    fi
+}
+
+
+

--- a/functions.sh
+++ b/functions.sh
@@ -25,31 +25,3 @@ print_deployment_info() {
     echo -e "\t$flag"
   done
 }
-
-# Function to check REMOTE_PATH and move contents of SRC_PATH
-make_relative_remote() {
-  if [[ -z "$REMOTE_PATH" && "$SRC_PATH" == "." ]]; then
-    echo "Default usage, no moving relative paths needed 👋"
-    return
-  fi
-
-  if [[ "$SRC_PATH" == "$REMOTE_PATH" ]]; then
-    echo "SRC_PATH and REMOTE_PATH are the same, no moving relative paths needed 👋"
-    return
-  fi
-
-  if [ "$SRC_PATH" == "." ]; then
-    # Use a temporary directory to avoid moving REMOTE_PATH into itself
-    TMP_DIR=$(mktemp -d) 
-    mv "$SRC_PATH"/* "$TMP_DIR"
-    mkdir -p "$REMOTE_PATH"
-    mv "$TMP_DIR"/* "$REMOTE_PATH"
-    rmdir "$TMP_DIR"
-  else
-    mkdir -p "$REMOTE_PATH"
-    mv "$SRC_PATH"/* "$REMOTE_PATH"
-  fi
-}
-
-
-

--- a/functions.sh
+++ b/functions.sh
@@ -42,16 +42,18 @@ make_relative_remote() {
     # Echo the paths for debugging
     echo "SRC_PATH: $SRC_PATH"
     echo "REMOTE_PATH: $REMOTE_PATH"
-    mkdir -p "$REMOTE_PATH"
     echo "Would have moved contents of SRC_PATH to REMOTE_PATH"
   
     if [ "$SRC_PATH" == "." ]; then
         # Use a temporary directory to avoid moving REMOTE_PATH into itself
         TMP_DIR=$(mktemp -d)
+        ls -la "$SRC_PATH"
         mv "$SRC_PATH"/* "$TMP_DIR"
+        mkdir -p "$REMOTE_PATH"
         mv "$TMP_DIR"/* "$REMOTE_PATH"
         rmdir "$TMP_DIR"
     else
+        mkdir -p "$REMOTE_PATH"
         mv "$SRC_PATH"/* "$REMOTE_PATH"
     fi
 }

--- a/functions.sh
+++ b/functions.sh
@@ -33,29 +33,22 @@ make_relative_remote() {
     return
   fi
 
-  # Not sure if this check is necessary
   if [[ "$SRC_PATH" == "$REMOTE_PATH" ]]; then
-      echo "SRC_PATH and REMOTE_PATH are the same, no moving relative paths needed 👋"
-      return
+    echo "SRC_PATH and REMOTE_PATH are the same, no moving relative paths needed 👋"
+    return
   fi
 
-    # Echo the paths for debugging
-    echo "SRC_PATH: $SRC_PATH"
-    echo "REMOTE_PATH: $REMOTE_PATH"
-    echo "Would have moved contents of SRC_PATH to REMOTE_PATH"
-  
-    if [ "$SRC_PATH" == "." ]; then
-        # Use a temporary directory to avoid moving REMOTE_PATH into itself
-        TMP_DIR=$(mktemp -d)
-        ls -la "$SRC_PATH"
-        mv "$SRC_PATH"/* "$TMP_DIR"
-        mkdir -p "$REMOTE_PATH"
-        mv "$TMP_DIR"/* "$REMOTE_PATH"
-        rmdir "$TMP_DIR"
-    else
-        mkdir -p "$REMOTE_PATH"
-        mv "$SRC_PATH"/* "$REMOTE_PATH"
-    fi
+  if [ "$SRC_PATH" == "." ]; then
+    # Use a temporary directory to avoid moving REMOTE_PATH into itself
+    TMP_DIR=$(mktemp -d) 
+    mv "$SRC_PATH"/* "$TMP_DIR"
+    mkdir -p "$REMOTE_PATH"
+    mv "$TMP_DIR"/* "$REMOTE_PATH"
+    rmdir "$TMP_DIR"
+  else
+    mkdir -p "$REMOTE_PATH"
+    mv "$SRC_PATH"/* "$REMOTE_PATH"
+  fi
 }
 
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+workspace/**/*

--- a/tests/test-make-relative-remote/data/repository-3/plugins/sample_plugin.txt
+++ b/tests/test-make-relative-remote/data/repository-3/plugins/sample_plugin.txt
@@ -1,0 +1,1 @@
+Sample plugin file

--- a/tests/test-make-relative-remote/data/repository-3/themes/sample_theme.txt
+++ b/tests/test-make-relative-remote/data/repository-3/themes/sample_theme.txt
@@ -1,0 +1,1 @@
+Sample theme file

--- a/tests/test-make-relative-remote/data/repository-3/uploads/sample_upload.txt
+++ b/tests/test-make-relative-remote/data/repository-3/uploads/sample_upload.txt
@@ -1,0 +1,1 @@
+Sample upload file

--- a/tests/test-make-relative-remote/data/repository-4/themes/beautiful-pro/sample_theme.txt
+++ b/tests/test-make-relative-remote/data/repository-4/themes/beautiful-pro/sample_theme.txt
@@ -1,0 +1,1 @@
+Sample theme file

--- a/tests/test-make-relative-remote/test.sh
+++ b/tests/test-make-relative-remote/test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Get the directory of the current script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${SCRIPT_DIR}/../common.sh"
+source "${SCRIPT_DIR}/../../functions.sh"
+
+setup() {
+    rm -rf /workspace/*
+    local test_data_dir="${SCRIPT_DIR}/data/repository-${1}/"
+    if [[ -d "${test_data_dir}" ]]; then
+        cp -r "${test_data_dir}"* /workspace/
+    fi
+    cd /workspace
+}
+
+# Test resulting directory structure from calling make_relative_remote
+# Expected output is the directory structure after moving the contents of SRC_PATH to REMOTE_PATH
+# e.g. make_relative_remote "/home/user/website" "/var/www/html" should return "/var/www/html/website"
+# 1st argument: SRC_PATH, 2nd argument: REMOTE_PATH, 3rd argument: EXPECTED_REMOTE_PATH
+test_make_relative_remote() {
+  setup "$1"
+  SRC_PATH=$2
+  REMOTE_PATH=$3
+  EXPECTED_REMOTE_PATH=$4
+
+  echo -e "${GREEN}REMOTE_PATH='$REMOTE_PATH' SRC_PATH='$SRC_PATH' EXPECTED_REMOTE_PATH='$EXPECTED_REMOTE_PATH'" 
+  # Should I cd into the test_dir?
+  make_relative_remote
+
+  if [[ "$REMOTE_PATH" != "$EXPECTED_REMOTE_PATH" ]]; then
+      echo -e "${RED}Test failed for SRC_PATH='$SRC_PATH' and REMOTE_PATH='$REMOTE_PATH': expected '$EXPECTED_REMOTE_PATH', got '$REMOTE_PATH'.${NC}"
+      return
+  fi
+}
+
+# Test cases, make remote directory relative to to the tests directory
+test_make_relative_remote "1" "." "" ""
+test_make_relative_remote "2" "./wp-content" "./wp-content" "./wp-content"
+# Ok, I think I am still not understanding how to use make relative remote. I need to test the following scenarios:
+# Need to walk through the actual scenerio seen, with the source being .
+# REMOTE_PATH=/wp-content
+#SRC_PATH=.
+#remote = ./wp-content
+#source (where I am at locally)= . (current folder), and aim is to make sure excludes goes from the base wp-content/uploads/
+# but can't test this... because it will start with top-level folder
+test_make_relative_remote "3" "." "wp-content/" "wp-content/"
+#test_make_relative_remote "./test_dir/remote/wp-content" ".test_dir/local/wp-content" "./test_dir/remote/wp-content"
+
+# Just deploying out wp-content, need to make sure the resulting folder structure matched expected excludes layout. But what is the difference?
+# REMOTE_PATH=/wp-content
+# SRC_PATH=.
+# EXPECTED_REMOTE_PATH= create wp-content, copy all contents of wp-content into it
+
+# Default: No movement happens
+# REMOTE_PATH=
+# SRC_PATH=.
+# EXPECTED_REMOTE_PATH= nothing changed
+
+# Individual theme, need to make sure resulting folder structure matches expected excludes
+# REMOTE_PATH=/wp-content/themes/beautiful-pro
+# SRC_PATH=.
+# EXPECTED_REMOTE_PATH=create wp-content/themes/beautiful-pro, copy all contents of beautiful-pro into the folder.

--- a/tests/test-make-relative-remote/test.sh
+++ b/tests/test-make-relative-remote/test.sh
@@ -10,6 +10,7 @@ setup() {
     rm -rf /workspace/*
     local test_data_dir="${SCRIPT_DIR}/data/repository-${1}/"
     if [[ -d "${test_data_dir}" ]]; then
+    # Works like GitHub action, checking out the workspace directory
         cp -r "${test_data_dir}"* /workspace/
     fi
     cd /workspace
@@ -18,47 +19,44 @@ setup() {
 # Test resulting directory structure from calling make_relative_remote
 # Expected output is the directory structure after moving the contents of SRC_PATH to REMOTE_PATH
 # e.g. make_relative_remote "/home/user/website" "/var/www/html" should return "/var/www/html/website"
-# 1st argument: SRC_PATH, 2nd argument: REMOTE_PATH, 3rd argument: EXPECTED_REMOTE_PATH
+# 1st argument: SRC_PATH, 2nd argument: REMOTE_PATH
+# How can I make sure the make test is not caching the docker and creating it fresh
 test_make_relative_remote() {
   setup "$1"
   SRC_PATH=$2
   REMOTE_PATH=$3
-  EXPECTED_REMOTE_PATH=$4
 
-  echo -e "${GREEN}REMOTE_PATH='$REMOTE_PATH' SRC_PATH='$SRC_PATH' EXPECTED_REMOTE_PATH='$EXPECTED_REMOTE_PATH'" 
-  # Should I cd into the test_dir?
+  echo -e "${GREEN}REMOTE_PATH='$REMOTE_PATH' SRC_PATH='$SRC_PATH'${NC}" 
   make_relative_remote
 
-  if [[ "$REMOTE_PATH" != "$EXPECTED_REMOTE_PATH" ]]; then
-      echo -e "${RED}Test failed for SRC_PATH='$SRC_PATH' and REMOTE_PATH='$REMOTE_PATH': expected '$EXPECTED_REMOTE_PATH', got '$REMOTE_PATH'.${NC}"
-      return
+  # Only compare the expected directory structure if REMOTE_PATH is not empty and REMOTE_PATH is not equal to SRC_PATH
+  if [[ -n "$REMOTE_PATH" && "$REMOTE_PATH" != "$SRC_PATH" ]]; then
+    # Verify that REMOTE_PATH and its folders exist in /workspace
+    if [ -d "/workspace/$REMOTE_PATH" ]; then
+        echo -e "${GREEN}REMOTE_PATH exists in /workspace${NC}"
+        
+        # Compare the contents of the moved REMOTE_PATH to the corresponding files in the data directory
+        EXPECTED_PATH="${SCRIPT_DIR}/data/repository-${1}/$SRC_PATH"
+        diff -r "/workspace/$REMOTE_PATH" "$EXPECTED_PATH"
+        
+        # Check the result of the diff command
+        if [[ $? -ne 0 ]]; then
+            echo -e "${RED}Verification failed: expected structure does not match.${NC}"
+        else
+            echo -e "${GREEN}Verification passed: expected structure matches.${NC}"
+        fi
+    else
+        echo -e "${RED}Verification failed: REMOTE_PATH does not exist in /workspace.${NC}"
+    fi
+  else
+    echo -e "${YELLOW}REMOTE_PATH is empty or equal to SRC_PATH, skipping comparison.${NC}"
   fi
 }
 
 # Test cases, make remote directory relative to to the tests directory
-test_make_relative_remote "1" "." "" ""
-test_make_relative_remote "2" "./wp-content" "./wp-content" "./wp-content"
-# Ok, I think I am still not understanding how to use make relative remote. I need to test the following scenarios:
-# Need to walk through the actual scenerio seen, with the source being .
-# REMOTE_PATH=/wp-content
-#SRC_PATH=.
-#remote = ./wp-content
-#source (where I am at locally)= . (current folder), and aim is to make sure excludes goes from the base wp-content/uploads/
-# but can't test this... because it will start with top-level folder
-test_make_relative_remote "3" "." "wp-content/" "wp-content/"
-#test_make_relative_remote "./test_dir/remote/wp-content" ".test_dir/local/wp-content" "./test_dir/remote/wp-content"
-
-# Just deploying out wp-content, need to make sure the resulting folder structure matched expected excludes layout. But what is the difference?
-# REMOTE_PATH=/wp-content
-# SRC_PATH=.
-# EXPECTED_REMOTE_PATH= create wp-content, copy all contents of wp-content into it
-
-# Default: No movement happens
-# REMOTE_PATH=
-# SRC_PATH=.
-# EXPECTED_REMOTE_PATH= nothing changed
-
-# Individual theme, need to make sure resulting folder structure matches expected excludes
-# REMOTE_PATH=/wp-content/themes/beautiful-pro
-# SRC_PATH=.
-# EXPECTED_REMOTE_PATH=create wp-content/themes/beautiful-pro, copy all contents of beautiful-pro into the folder.
+test_make_relative_remote "1" "." ""
+test_make_relative_remote "2" "./wp-content" "./wp-content"
+test_make_relative_remote "3" "." "wp-content/"
+test_make_relative_remote "4" "." "wp-content/themes/beautiful-pro" 
+test_make_relative_remote "5" "my-awesome-plugins" "wp-content/plugins" 
+test_make_relative_remote "6" "my-awesome-plugins/blues-brothers" "wp-content/plugins" 

--- a/tests/test_functions.sh
+++ b/tests/test_functions.sh
@@ -6,73 +6,141 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 source "${SCRIPT_DIR}/../functions.sh"
 
-# First argument represents the value of the FLAGS variable.
-# The rest of the arguments represent the expected values of the FLAGS_ARRAY.
-#
-# usage: test_parse_flags <FLAGS> <EXPECTED_FLAGS...>
-test_parse_flags() {
-  local test_case=$1
-  shift
-  local expected_args=("$@")
+# # First argument represents the value of the FLAGS variable.
+# # The rest of the arguments represent the expected values of the FLAGS_ARRAY.
+# #
+# # usage: test_parse_flags <FLAGS> <EXPECTED_FLAGS...>
+# test_parse_flags() {
+#   local test_case=$1
+#   shift
+#   local expected_args=("$@")
 
-  parse_flags "$test_case"
+#   parse_flags "$test_case"
 
-  local actual_count="${#FLAGS_ARRAY[@]}"
-  local expected_count="${#expected_args[@]}"
+#   local actual_count="${#FLAGS_ARRAY[@]}"
+#   local expected_count="${#expected_args[@]}"
 
-  if [[ "$actual_count" -ne "$expected_count" ]]; then
-    echo -e "${RED}Test failed for FLAGS='$test_case': expected $expected_count arguments, got $actual_count."
-    echo -e "\tActual arguments: ${FLAGS_ARRAY[*]}${NC}"
-    return
-  fi
+#   if [[ "$actual_count" -ne "$expected_count" ]]; then
+#     echo -e "${RED}Test failed for FLAGS='$test_case': expected $expected_count arguments, got $actual_count."
+#     echo -e "\tActual arguments: ${FLAGS_ARRAY[*]}${NC}"
+#     return
+#   fi
 
-  for i in "${!expected_args[@]}"; do
-    if [[ "${FLAGS_ARRAY[$i]}" != "${expected_args[$i]}" ]]; then
-      echo -e "${RED}Test failed for FLAGS='$test_case': expected '${expected_args[$i]}', got '${FLAGS_ARRAY[$i]}'.${NC}"
+#   for i in "${!expected_args[@]}"; do
+#     if [[ "${FLAGS_ARRAY[$i]}" != "${expected_args[$i]}" ]]; then
+#       echo -e "${RED}Test failed for FLAGS='$test_case': expected '${expected_args[$i]}', got '${FLAGS_ARRAY[$i]}'.${NC}"
+#       return
+#     fi
+#   done
+
+#   echo -e "${GREEN}Test passed for FLAGS=\"$test_case\".${NC}"
+# }
+
+# # Test cases
+# test_parse_flags \
+#   "-azvr --inplace --exclude='.*'" \
+#   "-azvr" \
+#   "--inplace" \
+#   "--exclude=.*"
+
+# test_parse_flags \
+#   '-azvr --inplace --exclude=".*"' \
+#   "-azvr" \
+#   "--inplace" \
+#   "--exclude=.*"
+
+# test_parse_flags \
+#   "-azvr --filter=':- .gitignore' --exclude='.*'" \
+#   "-azvr" \
+#   "--filter=:- .gitignore" \
+#   "--exclude=.*"
+
+# test_parse_flags \
+#   "-avzr --delete --filter='P /wp-uploads/**'" \
+#   "-avzr" \
+#   "--delete" \
+#   "--filter=P /wp-uploads/**"
+
+# test_parse_flags \
+#   "-avzr --delete --exclude='\$dollar'" \
+#   "-avzr" \
+#   "--delete" \
+#   "--exclude=\$dollar"
+
+# test_parse_flags \
+#   "-avzr --exclude='\`back-ticks\`'" \
+#   "-avzr" \
+#   "--exclude=\`back-ticks\`"
+
+# test_parse_flags \
+#   "-avzr --exclude='path\\with\\backslash'" \
+#   "-avzr" \
+#   "--exclude=path\\with\\backslash"
+
+# Test resulting directory structure from calling make_relative_remote
+# Expected output is the directory structure after moving the contents of SRC_PATH to REMOTE_PATH
+# e.g. make_relative_remote "/home/user/website" "/var/www/html" should return "/var/www/html/website"
+# 1st argument: SRC_PATH, 2nd argument: REMOTE_PATH, 3rd argument: EXPECTED_REMOTE_PATH
+test_make_relative_remote() {
+  setup
+  REMOTE_PATH=$1
+  SRC_PATH=$2
+  EXPECTED_REMOTE_PATH=$3
+
+  echo -e "${GREEN}REMOTE_PATH='$REMOTE_PATH' SRC_PATH='$SRC_PATH' EXPECTED_REMOTE_PATH='$EXPECTED_REMOTE_PATH'" 
+  # Should I cd into the test_dir?
+  make_relative_remote
+
+  if [[ "$REMOTE_PATH" != "$EXPECTED_REMOTE_PATH" ]]; then
+      echo -e "${RED}Test failed for SRC_PATH='$SRC_PATH' and REMOTE_PATH='$REMOTE_PATH': expected '$EXPECTED_REMOTE_PATH', got '$REMOTE_PATH'.${NC}"
       return
-    fi
-  done
-
-  echo -e "${GREEN}Test passed for FLAGS=\"$test_case\".${NC}"
+  fi
 }
 
-# Test cases
-test_parse_flags \
-  "-azvr --inplace --exclude='.*'" \
-  "-azvr" \
-  "--inplace" \
-  "--exclude=.*"
+setup() {
+  mkdir -p "test_dir/wp-content"
+  mkdir -p "test_dir/local/wp-content/uploads"
+  mkdir -p "test_dir/local/wp-content/plugins/mu-plugins"
+  mkdir -p "test_dir/local/wp-content/themes"
 
-test_parse_flags \
-  '-azvr --inplace --exclude=".*"' \
-  "-azvr" \
-  "--inplace" \
-  "--exclude=.*"
+  mkdir -p "test_dir/remote/"
 
-test_parse_flags \
-  "-azvr --filter=':- .gitignore' --exclude='.*'" \
-  "-azvr" \
-  "--filter=:- .gitignore" \
-  "--exclude=.*"
+  echo "Sample upload file" > "test_dir/local/wp-content/uploads/sample_upload.txt"
+  echo "Sample plugin file" > "test_dir/local/wp-content/plugins/sample_plugin.txt"
+  touch "test_dir/local/wp-content/plugins/mu-plugins/.gitkeep"
+  echo "Sample theme file" > "test_dir/local/wp-content/themes/sample_theme.txt"
 
-test_parse_flags \
-  "-avzr --delete --filter='P /wp-uploads/**'" \
-  "-avzr" \
-  "--delete" \
-  "--filter=P /wp-uploads/**"
+  echo "Created test_dir with wp-content structure and sample files."
+}
 
-test_parse_flags \
-  "-avzr --delete --exclude='\$dollar'" \
-  "-avzr" \
-  "--delete" \
-  "--exclude=\$dollar"
+cleanup() {
+  rm -rf ./test_dir
+}
 
-test_parse_flags \
-  "-avzr --exclude='\`back-ticks\`'" \
-  "-avzr" \
-  "--exclude=\`back-ticks\`"
+# Test cases, make remote directory relative to to the tests directory
+test_make_relative_remote "" "." ""
+test_make_relative_remote "./wp-content" "./wp-content" "./wp-content"
+# Ok, I think I am still not understanding how to use make relative remote. I need to test the following scenarios:
+# Need to walk through the actual scenerio seen, with the source being .
+# REMOTE_PATH=/wp-content
+#SRC_PATH=.
+#remote = ./wp-content
+#source (where I am at locally)= . (current folder), and aim is to make sure excludes goes from the base wp-content/uploads/
+# but can't test this... because it will start with top-level folder
+test_make_relative_remote "/wp-content" "." "/wp-content"
+#test_make_relative_remote "./test_dir/remote/wp-content" ".test_dir/local/wp-content" "./test_dir/remote/wp-content"
 
-test_parse_flags \
-  "-avzr --exclude='path\\with\\backslash'" \
-  "-avzr" \
-  "--exclude=path\\with\\backslash"
+# Just deploying out wp-content, need to make sure the resulting folder structure matched expected excludes layout. But what is the difference?
+# REMOTE_PATH=/wp-content
+# SRC_PATH=.
+# EXPECTED_REMOTE_PATH= create wp-content, copy all contents of wp-content into it
+
+# Default: No movement happens
+# REMOTE_PATH=
+# SRC_PATH=.
+# EXPECTED_REMOTE_PATH= nothing changed
+
+# Individual theme, need to make sure resulting folder structure matches expected excludes
+# REMOTE_PATH=/wp-content/themes/beautiful-pro
+# SRC_PATH=.
+# EXPECTED_REMOTE_PATH=create wp-content/themes/beautiful-pro, copy all contents of beautiful-pro into the folder.

--- a/tests/test_functions.sh
+++ b/tests/test_functions.sh
@@ -6,141 +6,73 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 source "${SCRIPT_DIR}/../functions.sh"
 
-# # First argument represents the value of the FLAGS variable.
-# # The rest of the arguments represent the expected values of the FLAGS_ARRAY.
-# #
-# # usage: test_parse_flags <FLAGS> <EXPECTED_FLAGS...>
-# test_parse_flags() {
-#   local test_case=$1
-#   shift
-#   local expected_args=("$@")
+# First argument represents the value of the FLAGS variable.
+# The rest of the arguments represent the expected values of the FLAGS_ARRAY.
+#
+# usage: test_parse_flags <FLAGS> <EXPECTED_FLAGS...>
+test_parse_flags() {
+  local test_case=$1
+  shift
+  local expected_args=("$@")
 
-#   parse_flags "$test_case"
+  parse_flags "$test_case"
 
-#   local actual_count="${#FLAGS_ARRAY[@]}"
-#   local expected_count="${#expected_args[@]}"
+  local actual_count="${#FLAGS_ARRAY[@]}"
+  local expected_count="${#expected_args[@]}"
 
-#   if [[ "$actual_count" -ne "$expected_count" ]]; then
-#     echo -e "${RED}Test failed for FLAGS='$test_case': expected $expected_count arguments, got $actual_count."
-#     echo -e "\tActual arguments: ${FLAGS_ARRAY[*]}${NC}"
-#     return
-#   fi
-
-#   for i in "${!expected_args[@]}"; do
-#     if [[ "${FLAGS_ARRAY[$i]}" != "${expected_args[$i]}" ]]; then
-#       echo -e "${RED}Test failed for FLAGS='$test_case': expected '${expected_args[$i]}', got '${FLAGS_ARRAY[$i]}'.${NC}"
-#       return
-#     fi
-#   done
-
-#   echo -e "${GREEN}Test passed for FLAGS=\"$test_case\".${NC}"
-# }
-
-# # Test cases
-# test_parse_flags \
-#   "-azvr --inplace --exclude='.*'" \
-#   "-azvr" \
-#   "--inplace" \
-#   "--exclude=.*"
-
-# test_parse_flags \
-#   '-azvr --inplace --exclude=".*"' \
-#   "-azvr" \
-#   "--inplace" \
-#   "--exclude=.*"
-
-# test_parse_flags \
-#   "-azvr --filter=':- .gitignore' --exclude='.*'" \
-#   "-azvr" \
-#   "--filter=:- .gitignore" \
-#   "--exclude=.*"
-
-# test_parse_flags \
-#   "-avzr --delete --filter='P /wp-uploads/**'" \
-#   "-avzr" \
-#   "--delete" \
-#   "--filter=P /wp-uploads/**"
-
-# test_parse_flags \
-#   "-avzr --delete --exclude='\$dollar'" \
-#   "-avzr" \
-#   "--delete" \
-#   "--exclude=\$dollar"
-
-# test_parse_flags \
-#   "-avzr --exclude='\`back-ticks\`'" \
-#   "-avzr" \
-#   "--exclude=\`back-ticks\`"
-
-# test_parse_flags \
-#   "-avzr --exclude='path\\with\\backslash'" \
-#   "-avzr" \
-#   "--exclude=path\\with\\backslash"
-
-# Test resulting directory structure from calling make_relative_remote
-# Expected output is the directory structure after moving the contents of SRC_PATH to REMOTE_PATH
-# e.g. make_relative_remote "/home/user/website" "/var/www/html" should return "/var/www/html/website"
-# 1st argument: SRC_PATH, 2nd argument: REMOTE_PATH, 3rd argument: EXPECTED_REMOTE_PATH
-test_make_relative_remote() {
-  setup
-  REMOTE_PATH=$1
-  SRC_PATH=$2
-  EXPECTED_REMOTE_PATH=$3
-
-  echo -e "${GREEN}REMOTE_PATH='$REMOTE_PATH' SRC_PATH='$SRC_PATH' EXPECTED_REMOTE_PATH='$EXPECTED_REMOTE_PATH'" 
-  # Should I cd into the test_dir?
-  make_relative_remote
-
-  if [[ "$REMOTE_PATH" != "$EXPECTED_REMOTE_PATH" ]]; then
-      echo -e "${RED}Test failed for SRC_PATH='$SRC_PATH' and REMOTE_PATH='$REMOTE_PATH': expected '$EXPECTED_REMOTE_PATH', got '$REMOTE_PATH'.${NC}"
-      return
+  if [[ "$actual_count" -ne "$expected_count" ]]; then
+    echo -e "${RED}Test failed for FLAGS='$test_case': expected $expected_count arguments, got $actual_count."
+    echo -e "\tActual arguments: ${FLAGS_ARRAY[*]}${NC}"
+    return
   fi
+
+  for i in "${!expected_args[@]}"; do
+    if [[ "${FLAGS_ARRAY[$i]}" != "${expected_args[$i]}" ]]; then
+      echo -e "${RED}Test failed for FLAGS='$test_case': expected '${expected_args[$i]}', got '${FLAGS_ARRAY[$i]}'.${NC}"
+      return
+    fi
+  done
+
+  echo -e "${GREEN}Test passed for FLAGS=\"$test_case\".${NC}"
 }
 
-setup() {
-  mkdir -p "test_dir/wp-content"
-  mkdir -p "test_dir/local/wp-content/uploads"
-  mkdir -p "test_dir/local/wp-content/plugins/mu-plugins"
-  mkdir -p "test_dir/local/wp-content/themes"
+# Test cases
+test_parse_flags \
+  "-azvr --inplace --exclude='.*'" \
+  "-azvr" \
+  "--inplace" \
+  "--exclude=.*"
 
-  mkdir -p "test_dir/remote/"
+test_parse_flags \
+  '-azvr --inplace --exclude=".*"' \
+  "-azvr" \
+  "--inplace" \
+  "--exclude=.*"
 
-  echo "Sample upload file" > "test_dir/local/wp-content/uploads/sample_upload.txt"
-  echo "Sample plugin file" > "test_dir/local/wp-content/plugins/sample_plugin.txt"
-  touch "test_dir/local/wp-content/plugins/mu-plugins/.gitkeep"
-  echo "Sample theme file" > "test_dir/local/wp-content/themes/sample_theme.txt"
+test_parse_flags \
+  "-azvr --filter=':- .gitignore' --exclude='.*'" \
+  "-azvr" \
+  "--filter=:- .gitignore" \
+  "--exclude=.*"
 
-  echo "Created test_dir with wp-content structure and sample files."
-}
+test_parse_flags \
+  "-avzr --delete --filter='P /wp-uploads/**'" \
+  "-avzr" \
+  "--delete" \
+  "--filter=P /wp-uploads/**"
 
-cleanup() {
-  rm -rf ./test_dir
-}
+test_parse_flags \
+  "-avzr --delete --exclude='\$dollar'" \
+  "-avzr" \
+  "--delete" \
+  "--exclude=\$dollar"
 
-# Test cases, make remote directory relative to to the tests directory
-test_make_relative_remote "" "." ""
-test_make_relative_remote "./wp-content" "./wp-content" "./wp-content"
-# Ok, I think I am still not understanding how to use make relative remote. I need to test the following scenarios:
-# Need to walk through the actual scenerio seen, with the source being .
-# REMOTE_PATH=/wp-content
-#SRC_PATH=.
-#remote = ./wp-content
-#source (where I am at locally)= . (current folder), and aim is to make sure excludes goes from the base wp-content/uploads/
-# but can't test this... because it will start with top-level folder
-test_make_relative_remote "/wp-content" "." "/wp-content"
-#test_make_relative_remote "./test_dir/remote/wp-content" ".test_dir/local/wp-content" "./test_dir/remote/wp-content"
+test_parse_flags \
+  "-avzr --exclude='\`back-ticks\`'" \
+  "-avzr" \
+  "--exclude=\`back-ticks\`"
 
-# Just deploying out wp-content, need to make sure the resulting folder structure matched expected excludes layout. But what is the difference?
-# REMOTE_PATH=/wp-content
-# SRC_PATH=.
-# EXPECTED_REMOTE_PATH= create wp-content, copy all contents of wp-content into it
-
-# Default: No movement happens
-# REMOTE_PATH=
-# SRC_PATH=.
-# EXPECTED_REMOTE_PATH= nothing changed
-
-# Individual theme, need to make sure resulting folder structure matches expected excludes
-# REMOTE_PATH=/wp-content/themes/beautiful-pro
-# SRC_PATH=.
-# EXPECTED_REMOTE_PATH=create wp-content/themes/beautiful-pro, copy all contents of beautiful-pro into the folder.
+test_parse_flags \
+  "-avzr --exclude='path\\with\\backslash'" \
+  "-avzr" \
+  "--exclude=path\\with\\backslash"


### PR DESCRIPTION
# JIRA Ticket

[CICD-761](https://wpengine.atlassian.net/browse/CICD-761)

## What Are We Doing Here

Customer reports that mu-plugins are being deleted when deploying with the GitHub Action. The plugins that are mentioned as being deleted are already part of our [global excludes list in wpengine/site-deploy](https://github.com/wpengine/site-deploy/blob/5c8b1aa9e9db707b8bfa7dbcaa1c8e86e3fa59f9/exclude.txt#L47-L57).

Reported in: https://github.com/wpengine/github-action-wpe-site-deploy/issues/91

To fix this, we are removing out the relative folder structure that was on the excludes list. This will help the rsynch command properly exclude the files, no matter what the folder structure happens to be.


[CICD-761]: https://wpengine.atlassian.net/browse/CICD-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ