### PR TITLE
[CICD-428] Remove notify step from e2e deploy

### DIFF
--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -1,7 +1,7 @@
 name: Test e2e Deploy to WP Engine
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/60 * * * *'
   push:
     branches:
       - main
@@ -41,18 +41,3 @@ jobs:
       - name: Validate deploy results
         run: |
           [ ${{ fromJson(steps.fetchResult.outputs.response).status }} = "success" ] || exit 1
-  notify:
-    runs-on: ubuntu-latest
-    if: ${{ !cancelled() }}
-    needs: run_action
-    steps:
-      - name: Notify slack on failure
-        if: needs.run_action.result == 'failure' && github.ref == 'refs/heads/main'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          # Channel: status-site-deploy
-          channel_id: C04ELD8NMT4
-          status: FAILED
-          color: danger


### PR DESCRIPTION
# JIRA Ticket

[CICD-428](https://wpengine.atlassian.net/browse/CICD-428)

## What Are We Doing Here

Removes the notify step of our e2e workflow. The failures in this workflow have consistently been unrelated to the site-deploy image itself and are therefore not actionable. Instead, they indicate an issue with some other service we depend on (GitHub, Docker Hub, SSH Gateway, WPE User Portal). These services are either out of our control or are already monitored in other ways.

This also bumps the cron schedule to 1 per hour.

**Bonus**: gets rid of a dependency on `voxmedia/github-action-slack-notify-build`, which has been deprecated.


[CICD-428]: https://wpengine.atlassian.net/browse/CICD-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ