### PR TITLE
[CICD-892] Add wpe-update-source-selector mu plugin to exclude list

### DIFF
--- a/tests/fixtures/excludes/exclude_from_mu_plugins.txt
+++ b/tests/fixtures/excludes/exclude_from_mu_plugins.txt
@@ -31,4 +31,5 @@ _wpeprivate
 /wpe-elasticpress-autosuggest-logger*
 /wpe-cache-plugin*
 /wp-cache-memcached*
+/wpe-update-source-selector*
 /local-by-flywheel-live-link-helper.php

--- a/tests/fixtures/excludes/exclude_from_root.txt
+++ b/tests/fixtures/excludes/exclude_from_root.txt
@@ -45,4 +45,5 @@ _wpeprivate
 /wp-content/mu-plugins/wpe-elasticpress-autosuggest-logger*
 /wp-content/mu-plugins/wpe-cache-plugin*
 /wp-content/mu-plugins/wp-cache-memcached*
+/wp-content/mu-plugins/wpe-update-source-selector*
 /wp-content/mu-plugins/local-by-flywheel-live-link-helper.php

--- a/tests/fixtures/excludes/exclude_from_wp_content.txt
+++ b/tests/fixtures/excludes/exclude_from_wp_content.txt
@@ -45,4 +45,5 @@ _wpeprivate
 /mu-plugins/wpe-elasticpress-autosuggest-logger*
 /mu-plugins/wpe-cache-plugin*
 /mu-plugins/wp-cache-memcached*
+/mu-plugins/wpe-update-source-selector*
 /mu-plugins/local-by-flywheel-live-link-helper.php

--- a/utils/generate_path_excludes.sh
+++ b/utils/generate_path_excludes.sh
@@ -107,6 +107,7 @@ print_dynamic_excludes() {
     wpe-elasticpress-autosuggest-logger*
     wpe-cache-plugin*
     wp-cache-memcached*
+    wpe-update-source-selector*
     # Local specific files
     local-by-flywheel-live-link-helper.php
   )


### PR DESCRIPTION
# JIRA Ticket

[CICD-892](https://wpengine.atlassian.net/browse/CICD-892)

## What Are We Doing Here

A new mu-plugin should be ignored in site deploys. We can do so by adding the plugin dir to our excludes script.
