### PR TITLE
[MARIO-570] Adding dependabot autoappoval/merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@
 package.json @pe-domino-bot @wpengine/mario
 package-lock.json @pe-domino-bot @wpengine/mario
 Dockerfile @pe-domino-bot @wpengine/mario
+.github/workflows/*.yml @pe-domino-bot @wpengine/mario
+.github/workflows/*.yaml @pe-domino-bot @wpengine/mario

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
 * @wpengine/mario
+
+# Dependency files: both the bot and the team are code owners for these paths
+package.json @pe-domino-bot @wpengine/mario
+package-lock.json @pe-domino-bot @wpengine/mario
+Dockerfile @pe-domino-bot @wpengine/mario
+docker-compose.yml @pe-domino-bot @wpengine/mario

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,3 @@
 package.json @pe-domino-bot @wpengine/mario
 package-lock.json @pe-domino-bot @wpengine/mario
 Dockerfile @pe-domino-bot @wpengine/mario
-docker-compose.yml @pe-domino-bot @wpengine/mario

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
-    reviewers:
-      - "wpengine/mario"
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/assets"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
-    reviewers:
-      - "wpengine/mario"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
   - package-ecosystem: "npm"
-    directory: "/assets"
+    directory: "/"
     schedule:
       interval: "daily"
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -23,4 +24,3 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
-    

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -16,3 +23,4 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
+    

--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -1,0 +1,29 @@
+name: Dependabot Automation
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{github.actor == 'dependabot[bot]'}}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{secrets.GITHUB_TOKEN}}"
+      - name: Approve PR
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.BOT_APPROVAL_TOKEN}}
+        run: gh pr review --approve "$PR_URL"
+      - name: Enable auto-merge
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.BOT_APPROVAL_TOKEN}}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
# JIRA Ticket

[MARIO-570](https://wpengine.atlassian.net/browse/MARIO-570)

## What Are We Doing Here

Adding config for dependabot to auto approve and merge minor and patch dep updates that pass ci


[MARIO-570]: https://wpengine.atlassian.net/browse/MARIO-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ